### PR TITLE
patched usage of inboudProperties so that in Documentum custom properties of datatype other that String can be updated properly

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -1,0 +1,3 @@
+<factorypath>
+    <factorypathentry kind="PLUGIN" id="org.mule.tooling.devkit.apt" enabled="true" runInBatchMode="false"/>
+</factorypath>

--- a/mule-project.xml
+++ b/mule-project.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<mule-project xmlns="http://www.mulesoft.com/tooling/project" runtimeId="org.mule.tooling.server.3.6.1.ee" schemaVersion="3.5.0.0">
+    <name>cmis-connector</name>
+    <description></description>
+</mule-project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.mule.modules</groupId>
     <artifactId>mule-module-cmis</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.0-threadsolutions</version>
     <packaging>mule-module</packaging>
     <name>Mule CMIS Connector</name>
 

--- a/src/main/app/mule-deploy.properties
+++ b/src/main/app/mule-deploy.properties
@@ -1,0 +1,6 @@
+#** GENERATED CONTENT ** Mule Application Deployment Descriptor
+#Thu Apr 16 09:35:36 CEST 2015
+redeployment.enabled=true
+encoding=UTF-8
+config.resources=
+domain=default

--- a/src/main/java/org/mule/module/cmis/ChemistryCMISFacade.java
+++ b/src/main/java/org/mule/module/cmis/ChemistryCMISFacade.java
@@ -957,14 +957,14 @@ public class ChemistryCMISFacade implements CMISFacade {
             while (keySetItr.hasNext()) {
                 Map.Entry<String, String> entry = keySetItr.next();
                 String currentKey = entry.getKey();
-                String currentVal = entry.getValue();
+                Object currentVal = entry.getValue();
 
                 // Don't waste our time with empty properties.
                 if (currentVal != null) {
                     // Determine if this is a multi-valued property.
                     if (currentKey.toLowerCase().startsWith("m:")) {
                         // This is a multi-valued property. Each value is separated by a ','.
-                        String[] valArray = currentVal.split(",");
+                        String[] valArray = ((String)currentVal).split(",");
 
                         List<String> propArray = new ArrayList<String>(Arrays.asList(valArray));
                         returnMap.put(currentKey.substring(2), propArray);


### PR DESCRIPTION
Case number 00021844 in MuleSoft customer portal was opened to report the issue, described below:
I've a problem with CMIS connector to Documentum, for operation "Update object properties".
When I try to update a Documentum property "stato_fattura", type integer, I always have this error:
"
1. java.math.BigInteger cannot be cast to java.lang.String (java.lang.ClassCastException)
org.mule.module.cmis.ChemistryCMISFacade:960 (null)
"
The problem is the method ChemistryCMISFacade.translateInboundProperties() manage only string values, and Documentum don't accept a different type to integer.

Below my example flow:
"
<flow name="spike-documentum-update">
<http:listener config-ref="HTTP_Listener_Configuration" path="/update" doc:name="/update"/>
<scripting:transformer doc:name="Set propertiesRef">
<scripting:script engine="Groovy"><![CDATA[//def m = [:]
Map<String, Object> m = new HashMap<String, Object>();
m.stato_fattura = new BigInteger(30);
m.note_fattura = "Test nota";
m.inviato_sdi = "Test inviato Sdi";
m.sezionale = "Test sezionale";

flowVars.propertiesRef = m;

return payload;]]></scripting:script>
</scripting:transformer>
<cmis:get-object-by-id config-ref="CMIS" objectId="09b46c4b80002d86" doc:name="CMIS - Get object by id"/>
<cmis:update-object-properties config-ref="CMIS" objectId="09b46c4b80002d86" doc:name="CMIS - Update object properties">
<cmis:properties ref="#[flowVars.propertiesRef]"/>
</cmis:update-object-properties>
</flow>
"